### PR TITLE
Fix typo

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -84,7 +84,7 @@ html(class='no-js')
                                             br
                                             i.icon-check.atk-swatch-green
                                             &nbsp;
-                                            | Use Heiroku-style buildpacks, Dockerfile or Procfile
+                                            | Use Heroku-style buildpacks, Dockerfile or Procfile
                                             br
                                             i.icon-check.atk-swatch-green
                                             &nbsp;


### PR DESCRIPTION
Noticed Heroku had an extra `i` in it.